### PR TITLE
Fix NEE related statistical weight bug

### DIFF
--- a/mitsuba/src/integrators/path/guided_path.cpp
+++ b/mitsuba/src/integrators/path/guided_path.cpp
@@ -2149,7 +2149,7 @@ public:
 
         if (nVertices > 0 && !m_isFinalIter) {
             for (int i = 0; i < nVertices; ++i) {
-                vertices[i].commit(*m_sdTree, m_doNee ? 0.5f : 1.0f, m_spatialFilter, m_directionalFilter, m_isBuilt ? m_bsdfSamplingFractionLoss : EBsdfSamplingFractionLoss::ENone, rRec.sampler);
+                vertices[i].commit(*m_sdTree, m_nee == EKickstart && m_doNee ? 0.5f : 1.0f, m_spatialFilter, m_directionalFilter, m_isBuilt ? m_bsdfSamplingFractionLoss : EBsdfSamplingFractionLoss::ENone, rRec.sampler);
             }
         }
 


### PR DESCRIPTION
The vertex commit loop at the end of the GuidedPathTracer Li() method
would always halve the statistical weight when NEE is set to EAlways.

The section was fixed to now only halve the weight if NEE is set to
EKickstart and still active (i.e. < 128 samples rendered).