### PR TITLE
Fix UAF caused by invalidated reference to node

### DIFF
--- a/mitsuba/src/integrators/path/guided_path.cpp
+++ b/mitsuba/src/integrators/path/guided_path.cpp
@@ -494,7 +494,7 @@ public:
 
                     m_nodes[sNode.nodeIndex].setChild(i, static_cast<uint16_t>(m_nodes.size()));
                     m_nodes.emplace_back();
-                    m_nodes.back().setSum(otherNode.sum(i) / 4);
+                    m_nodes.back().setSum(sNode.otherDTree->m_nodes[sNode.otherNodeIndex].sum(i) / 4);
 
                     if (m_nodes.size() > std::numeric_limits<uint16_t>::max()) {
                         SLog(EWarn, "DTreeWrapper hit maximum children count.");


### PR DESCRIPTION
**Issue:**
`emplace_back()` invalidates all references to its content if new memory has to be allocated as per https://en.cppreference.com/w/cpp/container/vector/emplace_back, which happens in line #496. In the following line however, `otherNode.sum()` is called, which runs into a Use-After-Free if `sNode.otherDTree` happens to be `this`, as the reference

```cpp
const QuadTreeNode& otherNode = sNode.otherDTree->m_nodes[sNode.otherNodeIndex];
```

gets invalidated after the `emplace_back()`.

**Fix:**
Replaced use of reference after invalidation with direct access to node.